### PR TITLE
Revert "Remove deprecated package"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,9 @@ markdown_extensions:
       smart_enable: all
   - pymdownx.caret
   - pymdownx.details
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:materialx.emoji.twemoji
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite


### PR DESCRIPTION
Reverts openwallet-foundation/tac#95

This seems to break more than just emoji's and also breaks the icons that we use within the website.